### PR TITLE
added more supported games

### DIFF
--- a/metamod/src/game_support.cpp
+++ b/metamod/src/game_support.cpp
@@ -10,7 +10,7 @@ const game_modinfo_t g_known_games[] = {
 	// Previously enumerated in this sourcefile, the list is now kept in a
 	// separate file, generated based on game information stored in a
 	// convenient db.
-	{ "action",             "ahl",                      "ahl.dll",                   "Action Half-Life"                                 }, // _i386.so,  + director's cut [2016], updated linux binary name
+	{ "action",             "ahl.so",                   "ahl.dll",                   "Action Half-Life"                                 }, // _i386.so,  + director's cut [2016], updated linux binary name
 	{ "ag",                 "ag.so",                    "ag.dll",                    "Adrenaline Gamer"                                 }, // .so file by OpenAG fork
 	{ "asheep",             nullptr,                    "hl.dll",                    "Azure Sheep"                                      }, // have no linux binary found!
 	{ "bdef",               "server.so",                "server.dll",                "Base Defense"                                     }, // placed in normal dll folder [2017]
@@ -26,20 +26,20 @@ const game_modinfo_t g_known_games[] = {
 	{ "cstrike",            "cs.so",                    "mp.dll",                    "Counter-Strike 1.6"                               },
 	{ "czero",              "cs.so",                    "mp.dll",                    "Counter-Strike:Condition Zero"                    },
 	{ "czeror",             "cz.so",                    "cz.dll",                    "Counter-Strike:Condition Zero Deleted Scenes"     },
-	{ "dcrisis",            "dc",                       "dc.dll",                    "Desert Crisis"                                    }, // _i386.so, updated linux binary name [2010]
+	{ "dcrisis",            "dc.so",                    "dc.dll",                    "Desert Crisis"                                    }, // _i386.so, updated linux binary name [2010]
 	{ "decay",              nullptr,                    "decay.dll",                 "Half-Life: Decay"                                 }, // have no linux binary!
 	{ "dmc",                "dmc.so",                   "dmc.dll",                   "Deathmatch Classic"                               },
 	{ "dod",                "dod.so",                   "dod.dll",                   "Day of Defeat"                                    },
 	{ "dpb",                "pb.i386.so",               "pb.dll",                    "Digital Paintball"                                }, // ...
-	{ "esf",                "../linuxdll/hl",		    "hl.dll",                    "Earth's Special Forces (old)"                     }, // _i386.so, workaround for basic-linux version
-	{ "esf",                "hl",           		    "hl.dll",                    "Earth's Special Forces"                           }, // _i386.so, full linux version
+	{ "esf",                "../linuxdll/hl.so",        "hl.dll",                    "Earth's Special Forces (old)"                     }, // _i386.so, workaround for basic-linux version
+	{ "esf",                "hl.so",           		    "hl.dll",                    "Earth's Special Forces"                           }, // _i386.so, full linux version
 	{ "existence",          nullptr,                    "existence.dll",             "Existence"                                        }, // have no linux binary found!
 	{ "firearms",           nullptr,                    "firearms.dll",              "Firearms"                                         }, // have no linux binary found!
-	{ "frontline",          "front",                    "frontline.dll",             "Frontline Force"                                  }, // _i386.so, updated linux binary name [2012]
+	{ "frontline",          "front.so",                 "frontline.dll",             "Frontline Force"                                  }, // _i386.so, updated linux binary name [2012]
 	{ "gangstawars",        nullptr,                    "gwars27.dll",               "Gangsta Wars"                                     }, // have no linux binary found!
 	{ "gangwars",           nullptr,                    "mp.dll",                    "Gangwars"                                         }, // have no linux binary found!
 	{ "gearbox",            "opfor.so",                 "opfor.dll",                 "Opposing Force"                                   },
-	{ "globalwarfare",      "gw",                       "mp.dll",                    "Global Warfare"                                   }, // _i386.so, updated linux binary name [2012]
+	{ "globalwarfare",      "gw.so",                    "mp.dll",                    "Global Warfare"                                   }, // _i386.so, updated linux binary name [2012]
 	{ "goldeneye",          nullptr,                    "mp.dll",                    "Goldeneye"                                        }, // have no linux binary found!
 	{ "hcfrenzy",           "hcfrenzy.so",              "hcfrenzy.dll",              "Headcrab Frenzy"                                  },
 	{ "hl15we",             "hl.so",                    "hl.dll",                    "Half-Life 1.5: Weapon Edition"                    },
@@ -69,15 +69,14 @@ const game_modinfo_t g_known_games[] = {
 	{ "recbb2",             "recb.so",                  "recb.dll",                  "Resident Evil : Cold Blood"                       },
 	{ "rewolf",             nullptr,                    "gunman.dll",                "Gunman Chronicles"                                }, // have no linux binary found!
 	{ "ricochet",           "ricochet.so",              "mp.dll",                    "Ricochet"                                         },
-	{ "rockcrowbar",        "rc.so",                    "rc.dll",                    "Rocket Crowbar"                                   },
-	{ "rockcrowbar",        "rc_i386.so",               "rc.dll",                    "Rocket Crowbar"                                   },
+	{ "rockcrowbar",        "rc.so",                    "rc.dll",                    "Rocket Crowbar"                                   }, // + _i386.so
 	{ "rspecies",           "hl.so",                    "hl.dll",                    "Rival Species"                                    },
 	{ "scihunt",            "shunt.so",                 "shunt.dll",                 "Scientist Hunt"                                   },
 	{ "ship",               "ship.so",                  "ship.dll",                  "The Ship"                                         },
 	{ "si",                 "si.so",                    "si.dll",                    "Science & Industry"                               },
 	{ "snow",               "snow.so",                  "snow.dll",                  "Snow-War"                                         },
 	{ "stargatetc",         "hl.so",                    "hl.dll",                    "StargateTC (Old, 1.x)"                            },
-	{ "stargatetc",         "stc",                      "hl.dll",                    "StargateTC (Updated, 2.x)"                        }, // _i386.so
+	{ "stargatetc",         "stc.so",                   "hl.dll",                    "StargateTC (Updated, 2.x)"                        }, // _i386.so
 	{ "stargatetc",         "stc_i386_opt.so",          "hl.dll",                    "StargateTC (Updated, 2.x)"                        }, // ...
 	{ "svencoop",           "hl.so",                    "hl.dll",                    "Sven Coop (Old)"                                  },
 	{ "svencoop",           "server.so",                "server.dll",                "Sven Coop (Steam)"                                },
@@ -87,17 +86,17 @@ const game_modinfo_t g_known_games[] = {
 	{ "timeless",           "pt.so",                    "timeless.dll",              "Project Timeless"                                 },
 	{ "tod",                "hl.so",                    "hl.dll",                    "Tour of Duty"                                     },
 	{ "trainhunters",       "th.so",                    "th.dll",                    "Train Hunters"                                    },
-	{ "ts",	                "ts",                       "mp.dll",		         	 "The Specialists"                                  }, //_i686.so, _i386.so 
+	{ "ts",	                "ts.so",                    "mp.dll",		         	 "The Specialists"                                  }, //_i686.so, _i386.so 
 	{ "tt",                 "tt.so",                    "tt.dll",                    "The Trenches"                                     },
 	{ "underworld",         "uw.so",                    "uw.dll",                    "Underworld Bloodline"                             },
 	{ "valve",              "hl.so",                    "hl.dll",                    "Half-Life"                                        },
 	{ "vs",                 "vs.so",                    "mp.dll",                    "VampireSlayer"                                    },
 	{ "wantedhl",           "hl.so",                    "wanted.dll",                "Wanted!"                                          },
-	{ "wizardwars",         "wizardwars",     			"wizardwars.dll",            "Wizard Wars (Steam)"                              },
-	{ "wizardwars_beta",    "wizardwars",     			"wizardwars.dll",            "Wizard Wars Beta (Steam)"                         },
+	{ "wizardwars",         "wizardwars.so",    		"wizardwars.dll",            "Wizard Wars (Steam)"                              },
+	{ "wizardwars_beta",    "wizardwars.so",     		"wizardwars.dll",            "Wizard Wars Beta (Steam)"                         }, // folder's name is not same as original. not duplicate
 	{ "wizwars",            "mp.so",                    "hl.dll",                    "Wizard Wars (Old)"                                },
-	{ "wormshl",            "wormshl",                  "wormshl.dll",               "WormsHL"                                          }, // _i586.so old, _i686.so steam
-	{ "zp",                 "hl",                       "mp.dll",                    "Zombie Panic"                                     }, // _i386.so
+	{ "wormshl",            "wormshl.so",               "wormshl.dll",               "WormsHL"                                          }, // _i586.so old, _i686.so steam
+	{ "zp",                 "hl.so",                    "mp.dll",                    "Zombie Panic"                                     }, // _i386.so
 
 
 	// End of list terminator:

--- a/metamod/src/game_support.cpp
+++ b/metamod/src/game_support.cpp
@@ -10,36 +10,36 @@ const game_modinfo_t g_known_games[] = {
 	// Previously enumerated in this sourcefile, the list is now kept in a
 	// separate file, generated based on game information stored in a
 	// convenient db.
-	{ "action",             "ahl_i386.so",              "ahl.dll",                   "Action Half-Life"                                 }, // + director's cut [2016], updated linux binary name
+	{ "action",             "ahl",                      "ahl.dll",                   "Action Half-Life"                                 }, // _i386.so,  + director's cut [2016], updated linux binary name
 	{ "ag",                 "ag.so",                    "ag.dll",                    "Adrenaline Gamer"                                 }, // .so file by OpenAG fork
 	{ "asheep",             nullptr,                    "hl.dll",                    "Azure Sheep"                                      }, // have no linux binary found!
 	{ "bdef",               "server.so",                "server.dll",                "Base Defense"                                     }, // placed in normal dll folder [2017]
 	{ "bg",                 "bg.so",                    "bg.dll",                    "The Battle Grounds"                               },
 	{ "bhl",                nullptr,                    "bhl.dll",                   "Brutal Half-Life"                                 }, // have no linux binary found!
 	{ "brainbread",         nullptr,                    "bb.dll",                    "Brain Bread"                                      }, // have no linux binary found!
-	{ "bshift",             "bshift.so",                "hl.dll",                    "Half-Life: Blue Shift"                            }, // ok
+	{ "bshift",             "bshift.so",                "hl.dll",                    "Half-Life: Blue Shift"                            },
 	{ "bumpercars",         nullptr,                    "hl.dll",                    "Bumper Cars"                                      }, // have no linux binary found!
 	{ "buzzybots",          nullptr,                    "bb.dll",                    "BuzzyBots"                                        }, // have no linux binary found!
 	{ "ckf3",               nullptr,                    "mp.dll",                    "Chicken Fortress 3"                               }, // have no linux binary found!, checked all versions (latest - Alpha 4)
 	{ "cs10",               nullptr,                    "mp.dll",                    "Counter-Strike 1.0"                               }, // have no linux binary found!
 	{ "csv15",              nullptr,                    "mp.dll",                    "Counter-Strike 1.5"                               }, // have no linux binary found!
-	{ "cstrike",            "cs.so",                    "mp.dll",                    "Counter-Strike 1.6"                               }, // ok
-	{ "czero",              "cs.so",                    "mp.dll",                    "Counter-Strike:Condition Zero"                    }, // ok
-	{ "czeror",             "cz.so",                    "cz.dll",                    "Counter-Strike:Condition Zero Deleted Scenes"     }, // ok
-	{ "dcrisis",            "dc_i386.so",               "dc.dll",                    "Desert Crisis"                                    }, // updated linux binary name [2010]
+	{ "cstrike",            "cs.so",                    "mp.dll",                    "Counter-Strike 1.6"                               },
+	{ "czero",              "cs.so",                    "mp.dll",                    "Counter-Strike:Condition Zero"                    },
+	{ "czeror",             "cz.so",                    "cz.dll",                    "Counter-Strike:Condition Zero Deleted Scenes"     },
+	{ "dcrisis",            "dc",                       "dc.dll",                    "Desert Crisis"                                    }, // _i386.so, updated linux binary name [2010]
 	{ "decay",              nullptr,                    "decay.dll",                 "Half-Life: Decay"                                 }, // have no linux binary!
-	{ "dmc",                "dmc.so",                   "dmc.dll",                   "Deathmatch Classic"                               }, // ok
-	{ "dod",                "dod.so",                   "dod.dll",                   "Day of Defeat"                                    }, // ok
-	{ "dpb",                "pb.i386.so",               "pb.dll",                    "Digital Paintball"                                }, // ok
-	{ "esf",                "../linuxdll/hl_i386.so",   "hl.dll",                    "Earth's Special Forces"                           }, // workaround for basic-linux version
-	{ "esf",                "hl_i386.so",               "hl.dll",                    "Earth's Special Forces"                           }, // full linux version
+	{ "dmc",                "dmc.so",                   "dmc.dll",                   "Deathmatch Classic"                               },
+	{ "dod",                "dod.so",                   "dod.dll",                   "Day of Defeat"                                    },
+	{ "dpb",                "pb.i386.so",               "pb.dll",                    "Digital Paintball"                                }, // ...
+	{ "esf",                "../linuxdll/hl",		    "hl.dll",                    "Earth's Special Forces (old)"                     }, // _i386.so, workaround for basic-linux version
+	{ "esf",                "hl",           		    "hl.dll",                    "Earth's Special Forces"                           }, // _i386.so, full linux version
 	{ "existence",          nullptr,                    "existence.dll",             "Existence"                                        }, // have no linux binary found!
 	{ "firearms",           nullptr,                    "firearms.dll",              "Firearms"                                         }, // have no linux binary found!
-	{ "frontline",          "front_i386.so",            "frontline.dll",             "Frontline Force"                                  }, // updated linux binary name [2012]
+	{ "frontline",          "front",                    "frontline.dll",             "Frontline Force"                                  }, // _i386.so, updated linux binary name [2012]
 	{ "gangstawars",        nullptr,                    "gwars27.dll",               "Gangsta Wars"                                     }, // have no linux binary found!
 	{ "gangwars",           nullptr,                    "mp.dll",                    "Gangwars"                                         }, // have no linux binary found!
-	{ "gearbox",            "opfor.so",                 "opfor.dll",                 "Opposing Force"                                   }, //ok
-	{ "globalwarfare",      "gw_i386.so",               "mp.dll",                    "Global Warfare"                                   }, //updated linux binary name [2012]
+	{ "gearbox",            "opfor.so",                 "opfor.dll",                 "Opposing Force"                                   },
+	{ "globalwarfare",      "gw",                       "mp.dll",                    "Global Warfare"                                   }, // _i386.so, updated linux binary name [2012]
 	{ "goldeneye",          nullptr,                    "mp.dll",                    "Goldeneye"                                        }, // have no linux binary found!
 	{ "hcfrenzy",           "hcfrenzy.so",              "hcfrenzy.dll",              "Headcrab Frenzy"                                  },
 	{ "hl15we",             "hl.so",                    "hl.dll",                    "Half-Life 1.5: Weapon Edition"                    },
@@ -77,29 +77,27 @@ const game_modinfo_t g_known_games[] = {
 	{ "si",                 "si.so",                    "si.dll",                    "Science & Industry"                               },
 	{ "snow",               "snow.so",                  "snow.dll",                  "Snow-War"                                         },
 	{ "stargatetc",         "hl.so",                    "hl.dll",                    "StargateTC (Old, 1.x)"                            },
-	{ "stargatetc",         "stc_i386.so",              "hl.dll",                    "StargateTC (Updated, 2.x)"                        },
-	{ "stargatetc",         "stc_i386_opt.so",          "hl.dll",                    "StargateTC (Updated, 2.x)"                        },
+	{ "stargatetc",         "stc",                      "hl.dll",                    "StargateTC (Updated, 2.x)"                        }, // _i386.so
+	{ "stargatetc",         "stc_i386_opt.so",          "hl.dll",                    "StargateTC (Updated, 2.x)"                        }, // ...
 	{ "svencoop",           "hl.so",                    "hl.dll",                    "Sven Coop (Old)"                                  },
 	{ "svencoop",           "server.so",                "server.dll",                "Sven Coop (Steam)"                                },
 	{ "swarm",              "swarm.so",                 "swarm.dll",                 "Swarm"                                            },
 	{ "tfc",                "tfc.so",                   "tfc.dll",                   "Team Fortress Classic"                            },
-	{ "thewastes",          "thewastes.so",             "thewastes.dll",             "The Wastes"                                       },
+	{ "thewastes",          "thewastes.so",             "thewastes.dll",             "The Wastes"                                       }, 
 	{ "timeless",           "pt.so",                    "timeless.dll",              "Project Timeless"                                 },
 	{ "tod",                "hl.so",                    "hl.dll",                    "Tour of Duty"                                     },
 	{ "trainhunters",       "th.so",                    "th.dll",                    "Train Hunters"                                    },
-	{ "ts",	                "ts_i686.so",               "mp.dll",		         	 "The Specialists"                                  },
-	{ "ts",                 "ts_i386.so",               "mp.dll",                    "The Specialists"                                  },
+	{ "ts",	                "ts",                       "mp.dll",		         	 "The Specialists"                                  }, //_i686.so, _i386.so 
 	{ "tt",                 "tt.so",                    "tt.dll",                    "The Trenches"                                     },
 	{ "underworld",         "uw.so",                    "uw.dll",                    "Underworld Bloodline"                             },
 	{ "valve",              "hl.so",                    "hl.dll",                    "Half-Life"                                        },
 	{ "vs",                 "vs.so",                    "mp.dll",                    "VampireSlayer"                                    },
 	{ "wantedhl",           "hl.so",                    "wanted.dll",                "Wanted!"                                          },
-	{ "wizardwars",         "wizardwars_i486.so",       "wizardwars.dll",            "Wizard Wars (Steam)"                              },
-	{ "wizardwars_beta",    "wizardwars_i486.so",       "wizardwars.dll",            "Wizard Wars Beta (Steam)"                         },
+	{ "wizardwars",         "wizardwars",     			"wizardwars.dll",            "Wizard Wars (Steam)"                              },
+	{ "wizardwars_beta",    "wizardwars",     			"wizardwars.dll",            "Wizard Wars Beta (Steam)"                         },
 	{ "wizwars",            "mp.so",                    "hl.dll",                    "Wizard Wars (Old)"                                },
-	{ "wormshl",            "wormshl_i586.so",          "wormshl.dll",               "WormsHL (Old)"                                    },
-	{ "wormshl",            "wormshl_i686.so",          "wormshl.dll",               "WormsHL (Steam)"                                  },
-	{ "zp",                 "hl_i386.so",               "mp.dll",                    "Zombie Panic"                                     },
+	{ "wormshl",            "wormshl",                  "wormshl.dll",               "WormsHL"                                          }, // _i586.so old, _i686.so steam
+	{ "zp",                 "hl",                       "mp.dll",                    "Zombie Panic"                                     }, // _i386.so
 
 
 	// End of list terminator:

--- a/metamod/src/game_support.cpp
+++ b/metamod/src/game_support.cpp
@@ -10,21 +10,97 @@ const game_modinfo_t g_known_games[] = {
 	// Previously enumerated in this sourcefile, the list is now kept in a
 	// separate file, generated based on game information stored in a
 	// convenient db.
-	{ "valve",      "hl.so",        "hl.dll",       "Half-Life" },
-	{ "bshift",     "bshift.so",    "hl.dll",       "Half-Life: Blue Shift" },
-	{ "ag",         "ag.so",        "ag.dll",       "Adrenaline Gamer" },
-	{ "cstrike",    "cs.so",        "mp.dll",       "Counter-Strike" },
-	{ "czero",      "cs.so",        "mp.dll",       "Counter-Strike:Condition Zero" },
-	{ "czeror",     "cz.so",        "cz.dll",       "Counter-Strike:Condition Zero Deleted Scenes" },
-	{ "ricochet",   "ricochet.so",  "mp.dll",       "Ricochet" },
-	{ "dmc",        "dmc.so",       "dmc.dll",      "Deathmatch Classic" },
-	{ "dod",        "dod.so",       "dod.dll",      "Day of Defeat" },
-	{ "tfc",        "tfc.so",       "tfc.dll",      "Team Fortress Classic" },
-	{ "gearbox",    "opfor.so",     "opfor.dll",    "Opposing Force" },
-	{ "ns",         "ns.so",        "ns.dll",       "Natural Selection" },
-	{ "nsp",        "ns.so",        "ns.dll",       "Natural Selection Beta" },
-	{ "ts",         "ts_i386.so",   "mp.dll",       "The Specialists" },
-	{ "esf",        "hl_i386.so",   "hl.dll",       "Earth's Special Forces" },
+	{ "action",             "ahl_i386.so",              "ahl.dll",                   "Action Half-Life"                                 }, // + director's cut [2016], updated linux binary name
+	{ "ag",                 "ag.so",                    "ag.dll",                    "Adrenaline Gamer"                                 }, // .so file by OpenAG fork
+	{ "asheep",             nullptr,                    "hl.dll",                    "Azure Sheep"                                      }, // have no linux binary found!
+	{ "bdef",               "server.so",                "server.dll",                "Base Defense"                                     }, // placed in normal dll folder [2017]
+	{ "bg",                 "bg.so",                    "bg.dll",                    "The Battle Grounds"                               },
+	{ "bhl",                nullptr,                    "bhl.dll",                   "Brutal Half-Life"                                 }, // have no linux binary found!
+	{ "brainbread",         nullptr,                    "bb.dll",                    "Brain Bread"                                      }, // have no linux binary found!
+	{ "bshift",             "bshift.so",                "hl.dll",                    "Half-Life: Blue Shift"                            }, // ok
+	{ "bumpercars",         nullptr,                    "hl.dll",                    "Bumper Cars"                                      }, // have no linux binary found!
+	{ "buzzybots",          nullptr,                    "bb.dll",                    "BuzzyBots"                                        }, // have no linux binary found!
+	{ "ckf3",               nullptr,                    "mp.dll",                    "Chicken Fortress 3"                               }, // have no linux binary found!, checked all versions (latest - Alpha 4)
+	{ "cs10",               nullptr,                    "mp.dll",                    "Counter-Strike 1.0"                               }, // have no linux binary found!
+	{ "csv15",              nullptr,                    "mp.dll",                    "Counter-Strike 1.5"                               }, // have no linux binary found!
+	{ "cstrike",            "cs.so",                    "mp.dll",                    "Counter-Strike 1.6"                               }, // ok
+	{ "czero",              "cs.so",                    "mp.dll",                    "Counter-Strike:Condition Zero"                    }, // ok
+	{ "czeror",             "cz.so",                    "cz.dll",                    "Counter-Strike:Condition Zero Deleted Scenes"     }, // ok
+	{ "dcrisis",            "dc_i386.so",               "dc.dll",                    "Desert Crisis"                                    }, // updated linux binary name [2010]
+	{ "decay",              nullptr,                    "decay.dll",                 "Half-Life: Decay"                                 }, // have no linux binary!
+	{ "dmc",                "dmc.so",                   "dmc.dll",                   "Deathmatch Classic"                               }, // ok
+	{ "dod",                "dod.so",                   "dod.dll",                   "Day of Defeat"                                    }, // ok
+	{ "dpb",                "pb.i386.so",               "pb.dll",                    "Digital Paintball"                                }, // ok
+	{ "esf",                "../linuxdll/hl_i386.so",   "hl.dll",                    "Earth's Special Forces"                           }, // workaround for basic-linux version
+	{ "esf",                "hl_i386.so",               "hl.dll",                    "Earth's Special Forces"                           }, // full linux version
+	{ "existence",          nullptr,                    "existence.dll",             "Existence"                                        }, // have no linux binary found!
+	{ "firearms",           nullptr,                    "firearms.dll",              "Firearms"                                         }, // have no linux binary found!
+	{ "frontline",          "front_i386.so",            "frontline.dll",             "Frontline Force"                                  }, // updated linux binary name [2012]
+	{ "gangstawars",        nullptr,                    "gwars27.dll",               "Gangsta Wars"                                     }, // have no linux binary found!
+	{ "gangwars",           nullptr,                    "mp.dll",                    "Gangwars"                                         }, // have no linux binary found!
+	{ "gearbox",            "opfor.so",                 "opfor.dll",                 "Opposing Force"                                   }, //ok
+	{ "globalwarfare",      "gw_i386.so",               "mp.dll",                    "Global Warfare"                                   }, //updated linux binary name [2012]
+	{ "goldeneye",          nullptr,                    "mp.dll",                    "Goldeneye"                                        }, // have no linux binary found!
+	{ "hcfrenzy",           "hcfrenzy.so",              "hcfrenzy.dll",              "Headcrab Frenzy"                                  },
+	{ "hl15we",             "hl.so",                    "hl.dll",                    "Half-Life 1.5: Weapon Edition"                    },
+	{ "hlrally",            "hlr.so",                   "hlrally.dll",               "HL-Rally"                                         },
+	{ "holywars",           "hl.so",                    "holywars.dll",              "Holy Wars"                                        },
+	{ "hostileintent",      "hl.so",                    "hl.dll",                    "Hostile Intent"                                   },
+	{ "ios",                "ios.so",                   "ios.dll",                   "International Online Soccer"                      },
+	{ "judgedm",            "judge.so",                 "mp.dll",                    "Judgement"                                        },
+	{ "kanonball",          "hl.so",                    "kanonball.dll",             "Kanonball"                                        },
+	{ "monkeystrike",       "ms.so",                    "monkey.dll",                "Monkeystrike"                                     },
+	{ "MorbidPR",           "morbid.so",                "morbid.dll",                "Morbid Inclination"                               },
+	{ "movein",             "hl.so",                    "hl.dll",                    "Move In!"                                         },
+	{ "msc",                nullptr,                    "ms.dll",                    "Master Sword Continued"                           },
+	{ "ns",                 "ns.so",                    "ns.dll",                    "Natural Selection"                                },
+	{ "nsp",                "ns.so",                    "ns.dll",                    "Natural Selection Beta"                           },
+	{ "og",                 "og.so",                    "og.dll",                    "Over Ground"                                      },
+	{ "ol",                 "ol.so",                    "hl.dll",                    "Outlawsmod"                                       },
+	{ "ops1942",            "spirit.so",                "spirit.dll",                "Operations 1942"                                  },
+	{ "osjb",               "osjb.so",                  "jail.dll",                  "Open-Source Jailbreak"                            },
+	{ "outbreak",           nullptr,                    "hl.dll",                    "Out Break"                                        }, // have no linux binary found!
+	{ "oz",                 "mp.so",                    "mp.dll",                    "Oz Deathmatch"                                    },
+	{ "paintball",          "pb.so",                    "mp.dll",                    "Paintball"                                        },
+	{ "penemy",             "pe.so",                    "pe.dll",                    "Public Enemy"                                     },
+	{ "ponreturn",          "ponr.so",                  "mp.dll",                    "Point of No Return"                               },
+	{ "pvk",                "hl.so",                    "hl.dll",                    "Pirates, Vikings and Knights"                     },
+	{ "rc2",                "rc2.so",                   "rc2.dll",                   "Rocket Crowbar 2"                                 },
+	{ "recbb2",             "recb.so",                  "recb.dll",                  "Resident Evil : Cold Blood"                       },
+	{ "rewolf",             nullptr,                    "gunman.dll",                "Gunman Chronicles"                                }, // have no linux binary found!
+	{ "ricochet",           "ricochet.so",              "mp.dll",                    "Ricochet"                                         },
+	{ "rockcrowbar",        "rc.so",                    "rc.dll",                    "Rocket Crowbar"                                   },
+	{ "rockcrowbar",        "rc_i386.so",               "rc.dll",                    "Rocket Crowbar"                                   },
+	{ "rspecies",           "hl.so",                    "hl.dll",                    "Rival Species"                                    },
+	{ "scihunt",            "shunt.so",                 "shunt.dll",                 "Scientist Hunt"                                   },
+	{ "ship",               "ship.so",                  "ship.dll",                  "The Ship"                                         },
+	{ "si",                 "si.so",                    "si.dll",                    "Science & Industry"                               },
+	{ "snow",               "snow.so",                  "snow.dll",                  "Snow-War"                                         },
+	{ "stargatetc",         "hl.so",                    "hl.dll",                    "StargateTC (Old, 1.x)"                            },
+	{ "stargatetc",         "stc_i386.so",              "hl.dll",                    "StargateTC (Updated, 2.x)"                        },
+	{ "stargatetc",         "stc_i386_opt.so",          "hl.dll",                    "StargateTC (Updated, 2.x)"                        },
+	{ "svencoop",           "hl.so",                    "hl.dll",                    "Sven Coop (Old)"                                  },
+	{ "svencoop",           "server.so",                "server.dll",                "Sven Coop (Steam)"                                },
+	{ "swarm",              "swarm.so",                 "swarm.dll",                 "Swarm"                                            },
+	{ "tfc",                "tfc.so",                   "tfc.dll",                   "Team Fortress Classic"                            },
+	{ "thewastes",          "thewastes.so",             "thewastes.dll",             "The Wastes"                                       },
+	{ "timeless",           "pt.so",                    "timeless.dll",              "Project Timeless"                                 },
+	{ "tod",                "hl.so",                    "hl.dll",                    "Tour of Duty"                                     },
+	{ "trainhunters",       "th.so",                    "th.dll",                    "Train Hunters"                                    },
+	{ "ts",	                "ts_i686.so",               "mp.dll",		         	 "The Specialists"                                  },
+	{ "ts",                 "ts_i386.so",               "mp.dll",                    "The Specialists"                                  },
+	{ "tt",                 "tt.so",                    "tt.dll",                    "The Trenches"                                     },
+	{ "underworld",         "uw.so",                    "uw.dll",                    "Underworld Bloodline"                             },
+	{ "valve",              "hl.so",                    "hl.dll",                    "Half-Life"                                        },
+	{ "vs",                 "vs.so",                    "mp.dll",                    "VampireSlayer"                                    },
+	{ "wantedhl",           "hl.so",                    "wanted.dll",                "Wanted!"                                          },
+	{ "wizardwars",         "wizardwars_i486.so",       "wizardwars.dll",            "Wizard Wars (Steam)"                              },
+	{ "wizardwars_beta",    "wizardwars_i486.so",       "wizardwars.dll",            "Wizard Wars Beta (Steam)"                         },
+	{ "wizwars",            "mp.so",                    "hl.dll",                    "Wizard Wars (Old)"                                },
+	{ "wormshl",            "wormshl_i586.so",          "wormshl.dll",               "WormsHL (Old)"                                    },
+	{ "wormshl",            "wormshl_i686.so",          "wormshl.dll",               "WormsHL (Steam)"                                  },
+	{ "zp",                 "hl_i386.so",               "mp.dll",                    "Zombie Panic"                                     },
+
 
 	// End of list terminator:
 	{ nullptr, nullptr, nullptr, nullptr }

--- a/metamod/src/game_support.cpp
+++ b/metamod/src/game_support.cpp
@@ -214,7 +214,7 @@ bool setup_gamedll(gamedll_t *gamedll)
 	}
 
 	// Neither override nor known-list found a gamedll.
-	if ((!known || !knowfn) && !g_config->m_gamedll)
+	if (!known && !g_config->m_gamedll)
 		return false;
 
 	// Use override-dll if specified.

--- a/metamod/src/game_support.cpp
+++ b/metamod/src/game_support.cpp
@@ -217,7 +217,7 @@ bool setup_gamedll(gamedll_t *gamedll)
 	}
 
 	// Neither override nor known-list found a gamedll.
-	if (!known && !g_config->m_gamedll)
+	if ((!known || !knowfn) && !g_config->m_gamedll)
 		return false;
 
 	// Use override-dll if specified.


### PR DESCRIPTION
# wtf :interrobang:

We are ([STAM](https://github.com/stamepicmorg) and [AurZum](https://github.com/Aleks-Z)) collected list of supported games from 
* [metamod Original](https://sourceforge.net/projects/metamod/files/Metamod%20Sourcecode/1.20/) (look at file "games.h"), 
* [metamod-p](https://github.com/jkivilin/metamod-p/blob/master/metamod/games.h) (old repo at [SF](https://sourceforge.net/p/metamod-p/code/ci/master/tree/metamod/games.h)) ([online list](http://metamod.org/supportedmods.html)),
* [metamod-am\metamod-hl1](https://github.com/alliedmodders/metamod-hl1/blob/master/metamod/games.h) by [alliedmodders](https://github.com/alliedmodders/)
* [metamod-p-cmake](https://github.com/SamVanheer/Metamod-P-CMake/blob/master/metamod/games.h) (just opmtimazed c-make fork).  

and we are merged it to one big cleanuped and actualized list. Why not?

Now we have checking mods to compablity with [ReHLDS](https://github.com/dreamstalker/rehlds)  and [Metamod-r](https://github.com/theAsmodai/metamod-r):
* we are cleaned list of available games and deleted old won-games. 'cause rehlds works only on steam-version -> metamod-r too, against original metamod. 

compablity tests table:
https://github.com/EpicMorgGames/metamod-r-game-tests