### PR TITLE
Added compablity table at readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,91 @@
 # metamod-r [![Build Status](http://teamcity.rehlds.org/app/rest/builds/buildType:(id:Metamod_Publish)/statusIcon)](http://teamcity.rehlds.org/viewType.html?buildTypeId=Metamod_Publish&guest=1) [![Download](https://camo.githubusercontent.com/2b15ec2fc402e02b66fde9eab7e896406caeddac/687474703a2f2f7265686c64732e6f72672f76657273696f6e2f6d6574616d6f642d2d722e737667)](http://teamcity.rehlds.org/guestAuth/downloadArtifacts.html?buildTypeId=Metamod_Publish&buildId=lastSuccessful) [![License: GPL v3](https://camo.githubusercontent.com/bf135a9cea09d0ea4bba410582c0e70ec8222736/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f4c6963656e73652d47504c25323076332d626c75652e737667)](https://www.gnu.org/licenses/gpl-3.0)
 
 Metamod-r is fully reworked fork of original Metamod by Jussi Kivilinna for Half-Life 1. It contains a huge number of performance optimizations and much cleaner code. The core was written using the JIT compiler.
+
+
+## Supported games
+:x: - OS is not supported :heavy_check_mark: - OS is supported 
+
+| Game \ Mod | Windows  | Linux   | Comment
+| ------------- | ------| ------|------|
+| [Action Half-Life](http://www.moddb.com/mods/action-half-life/downloads/) | :heavy_check_mark: |  :x: |  Have no linux binary. 
+| [Adrenaline Gamer](https://github.com/martinwebrant/agmod) | :heavy_check_mark: |  :heavy_check_mark:  |  
+| [Azure Sheep](http://www.moddb.com/mods/azure-sheep/downloads/) | :heavy_check_mark: |  :x: |  Have no linux binary.
+| [Base Defense](http://www.moddb.com/mods/b-def/downloads/) |  :heavy_check_mark: |  :heavy_check_mark: | 
+| [Brain Bread](http://www.moddb.com/mods/brainbread/downloads/) | :heavy_check_mark: |  :x: | Have no linux binary. 
+| [Brutal Half-Life](http://www.moddb.com/mods/brutal-half-life/downloads/) | :heavy_check_mark: |  :x: |  Have no linux binary. 
+| [Bumper Cars](http://www.moddb.com/mods/bumper-cars/downloads/) |   :heavy_check_mark: |  :x: | Have no linux binary. 
+| [BuzzyBots](http://www.moddb.com/mods/buzzybots/downloads) | :heavy_check_mark: |  :x: | Have no linux binary. 
+| [Chicken Fortress 3](http://www.moddb.com/mods/chicken-fortress-3/downloads/) | :heavy_check_mark:  | :x: | Have no linux binary. 
+| [Counter-Strike 1.0](http://www.moddb.com/mods/counter-strike/downloads/counter-strike-10-for-steam) | :heavy_check_mark:  | :x: | Have no linux binary. 
+| [Counter-Strike 1.5](http://www.moddb.com/mods/counter-strike/downloads/counter-strike-15-for-steam) | :heavy_check_mark:  | :x: | Have no linux binary. 
+| [Counter-Strike 1.6](http://store.steampowered.com/app/10/CounterStrike/) | :heavy_check_mark: | :heavy_check_mark: | 
+| [Counter-Strike:Condition Zero](http://store.steampowered.com/app/80/CounterStrike_Condition_Zero/) | :heavy_check_mark: | :heavy_check_mark:
+| [Counter-Strike:Condition Zero Deleted Scenes](http://store.steampowered.com/app/80/CounterStrike_Condition_Zero/) | :heavy_check_mark: | :heavy_check_mark: | SinglePlayer mod with MP-base.
+| [Day of Defeat](http://store.steampowered.com/app/30/Day_of_Defeat/) | :heavy_check_mark: | :heavy_check_mark:
+| [Deathmatch Classic](http://store.steampowered.com/app/40/Deathmatch_Classic/) | :heavy_check_mark: | :heavy_check_mark:
+| [Desert Crisis](http://www.moddb.com/mods/desert-crisis/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Digital Paintball](http://www.moddb.com/mods/digital-paintball/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Earth's Special Forces](http://www.moddb.com/mods/earths-special-forces/downloads/) | :heavy_check_mark: | :heavy_check_mark: |
+| [Existence](http://www.moddb.com/mods/existence/downloads/) | :heavy_check_mark: |  :x:  | Have no linux binary.
+| [Firearms](http://www.moddb.com/mods/firearms/downloads/) | :heavy_check_mark: |  :x:  | Have no linux binary.
+| [Frontline Force](http://www.moddb.com/mods/front-line-force/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Gangsta Wars](http://www.moddb.com/mods/gangsta-wars/downloads/) | :heavy_check_mark: |  :x: | Have no linux binary.
+| [Gangwars](http://www.moddb.com/mods/gangwars/downloads/) | :heavy_check_mark: |  :x: | Have no linux binary.
+| [Global Warfare](http://www.moddb.com/mods/global-warfare/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Goldeneye](http://www.moddb.com/mods/goldeneye-mod/downloads/) | :heavy_check_mark: |  :x: | Have no linux binary.
+| [Gunman Chronicles](http://www.moddb.com/games/gunman-chronicles/downloads/gunman-chronicles-steam-version/) | :heavy_check_mark: |  :x: | Have no linux binary. 
+| [HL-Rally](http://www.moddb.com/mods/hl-rally/downloads/) | :heavy_check_mark: |  :heavy_check_mark: |  
+| [Half-Life](http://store.steampowered.com/app/70/HalfLife/) | :heavy_check_mark: | :heavy_check_mark: | Also supported [Bugfixed and improved HL release](https://github.com/LevShisterov/BugfixedHL).
+| [Half-Life 1.5: Weapon Edition](http://www.moddb.com/mods/half-life-weapon-edition/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Half-Life: Blue Shift](http://store.steampowered.com/app/130/HalfLife_Blue_Shift/) | :heavy_check_mark: | :heavy_check_mark: | SinglePlayer mod with MP-base.
+| [Half-Life: Decay](http://www.moddb.com/mods/half-life-decay/downloads/) | :heavy_check_mark: | :x: | Have no linux binary.
+| [Headcrab Frenzy](http://www.moddb.com/mods/headcrab-frenzy/downloads/) | :heavy_check_mark: |  :heavy_check_mark: |  
+| [Holy Wars](http://www.moddb.com/mods/holy-wars/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Hostile Intent](http://www.moddb.com/mods/hostile-intent/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [International Online Soccer](http://www.moddb.com/mods/international-online-soccer/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Judgement](http://www.moddb.com/mods/judgement/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Kanonball](http://www.moddb.com/mods/kanonball/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Master Sword](http://www.moddb.com/mods/master-sword/downloads/) [Continued](http://www.moddb.com/mods/master-sword-continued-111/downloads) | :heavy_check_mark: |  :x: | Have no linux binary. 
+| [Monkeystrike](http://www.moddb.com/mods/monkeystrike/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Morbid Inclination](http://www.moddb.com/mods/morbid-inclination/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Move In!](http://www.moddb.com/mods/move-in/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Natural Selection](https://unknownworlds.com/ns/) | :heavy_check_mark: | :heavy_check_mark: | And `Beta` version too. 
+| [Open-Source Jailbreak](http://www.moddb.com/mods/open-source-jailbreak/downloads/) | :heavy_check_mark: |  :heavy_check_mark: |
+| [openAG](https://github.com/YaLTeR/OpenAG) |  :heavy_check_mark: |   :heavy_check_mark: | Is an open-source client of  `Adrenaline Gamer` mod.
+| [Operations 1942](http://www.moddb.com/mods/operations-1942/downloads/) | :heavy_check_mark: |  :heavy_check_mark:
+| [Opposing Force](http://store.steampowered.com/app/50/HalfLife_Opposing_Force/) | :heavy_check_mark: | :heavy_check_mark:
+| [Out Break](http://www.moddb.com/mods/outbreak-half-life/downloads/) | :heavy_check_mark: |  :x: | Have no linux binary.
+| [Outlawsmod](http://www.moddb.com/mods/outlaws/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Over Ground](http://www.moddb.com/mods/over-ground/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Oz Deathmatch](http://ozdeathmatch.com/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Paintball](http://www.bloodvayne.com/hlpb/downloads.htm) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Pirates, Vikings and Knights](http://www.moddb.com/mods/pirates-vikings-and-knights/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Point of No Return](http://www.moddb.com/mods/point-of-no-return/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Project Timeless](http://www.moddb.com/mods/project-timeless/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Public Enemy](http://www.moddb.com/mods/public-enemy/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Resident Evil : Cold Blood](http://www.moddb.com/mods/resident-evil-cold-blood/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Ricochet](http://store.steampowered.com/app/60/Ricochet/) | :heavy_check_mark: | :heavy_check_mark:
+| [Rival Species](http://www.rivalspecies.com/files.php) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Rocket Crowbar](http://hldm.org/files/mods/287-rocket-crowbar.html) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Rocket Crowbar 2](http://www.moddb.com/mods/rocket-crowbar-2/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Science & Industry](http://www.moddb.com/mods/science-and-industry/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Scientist Hunt](http://www.moddb.com/mods/scientist-hunt/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Snow-War](http://www.moddb.com/mods/snow-war/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [StargateTC](http://www.moddb.com/mods/stargatetc/downloads/) | :heavy_check_mark:  |  :heavy_check_mark: | All versions: `1.x` and `2.x`.
+| [Sven Coop](http://store.steampowered.com/app/225840/Sven_Coop/) | :heavy_check_mark:  |  :heavy_check_mark: | All versions: `legacy` and `steam`.
+| [Swarm](http://www.moddb.com/mods/swarm/downloads) | :heavy_check_mark:  |  :heavy_check_mark: |  
+| [Team Fortress Classic](http://store.steampowered.com/app/20/Team_Fortress_Classic/) | :heavy_check_mark: | :heavy_check_mark:
+| [The Battle Grounds](http://www.moddb.com/mods/battle-grounds/downloads/) | :heavy_check_mark:  |  :heavy_check_mark: |  
+| [The Ship](http://www.moddb.com/mods/the-ship) | :heavy_check_mark:  |  :heavy_check_mark: |  
+| [The Specialists](http://www.moddb.com/mods/the-specialists/downloads/) | :heavy_check_mark: | :heavy_check_mark:
+| [The Trenches](http://www.moddb.com/mods/the-trenches-half-life/downloads/) | :heavy_check_mark:  |  :heavy_check_mark: 
+| [The Wastes](http://www.moddb.com/mods/the-wastes/downloads/) | :heavy_check_mark:  |  :heavy_check_mark: 
+| [Tour of Duty](http://www.moddb.com/mods/tour-of-duty/downloads/) | :heavy_check_mark:  |  :heavy_check_mark: 
+| [Train Hunters](http://www.moddb.com/games/half-life/addons?filter=t&kw=Train+Hunters&category=&licence=&timeframe=) | :heavy_check_mark:  |  :heavy_check_mark: 
+| [Underworld Bloodline](http://www.moddb.com/mods/underworld-bloodline/downloads/) | :heavy_check_mark:  |  :heavy_check_mark: 
+| [VampireSlayer](http://www.moddb.com/mods/vampire-slayer/downloads/) | :heavy_check_mark:  |  :heavy_check_mark: 
+| [Wanted!](http://www.moddb.com/mods/wanted-the-western-mod-steam/downloads/) | :heavy_check_mark:  |  :heavy_check_mark: 
+| [Wizard Wars](http://www.moddb.com/mods/wizard-wars/downloads/) | :heavy_check_mark: |  :heavy_check_mark: | And `Beta` version too. 
+| [WormsHL](http://www.moddb.com/mods/wormshl/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 
+| [Zombie Panic](http://www.moddb.com/mods/zombie-panic/downloads/) | :heavy_check_mark: |  :heavy_check_mark: 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Metamod-r is fully reworked fork of original Metamod by Jussi Kivilinna for Half
 
 | Game \ Mod | Windows  | Linux   | Comment
 | ------------- | ------| ------|------|
-| [Action Half-Life](http://www.moddb.com/mods/action-half-life/downloads/) | :heavy_check_mark: |  :x: |  Have no linux binary. 
+| [Action Half-Life](http://www.moddb.com/mods/action-half-life/downloads/) | :heavy_check_mark: |  :heavy_check_mark: | 
 | [Adrenaline Gamer](https://github.com/martinwebrant/agmod) | :heavy_check_mark: |  :heavy_check_mark:  |  
 | [Azure Sheep](http://www.moddb.com/mods/azure-sheep/downloads/) | :heavy_check_mark: |  :x: |  Have no linux binary.
 | [Base Defense](http://www.moddb.com/mods/b-def/downloads/) |  :heavy_check_mark: |  :heavy_check_mark: | 


### PR DESCRIPTION
After #25 PR I think this info will be useful if this table will be presented in readme.md.

## Example:

:x: - OS is not supported :heavy_check_mark: - OS is supported 

| Game \ Mod | Windows  | Linux   | Comment
| ------------- | ------| ------|------|
| <...>
| [Half-Life](http://store.steampowered.com/app/70/HalfLife/) | :heavy_check_mark: | :heavy_check_mark: | Also supported [Bugfixed and improved HL release](https://github.com/LevShisterov/BugfixedHL).
| [Half-Life: Decay](http://www.moddb.com/mods/half-life-decay/downloads/) | :heavy_check_mark: | :x: | Have no linux binary.
| <...>
| etc